### PR TITLE
Fix `graph-cli` fork resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "deploy": "graph deploy jameslefrere/mStable --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "git@github.com:JamesLefrere/graph-cli.git#fix-tuple-arrays-for-0.17.1",
+    "@graphprotocol/graph-cli": "https://github.com/JamesLefrere/graph-cli.git#fix-tuple-arrays-for-0.17.1",
     "@graphprotocol/graph-ts": "^0.17.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,9 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@graphprotocol/graph-cli@git@github.com:JamesLefrere/graph-cli.git#fix-tuple-arrays-for-0.17.1":
+"@graphprotocol/graph-cli@https://github.com/JamesLefrere/graph-cli.git#fix-tuple-arrays-for-0.17.1":
   version "0.17.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.17.1.tgz#d1e1ded8d405574439ebfafa5c765bd6681d09ef"
-  integrity sha512-lFNRNwLXjWHKkFLCwWJiYdeCAQw6yp4ytG5nH2fKS9PFKMgmYppTdVkyp0kANPOLFgodeH8rIqiLUPI/NsLuQQ==
+  resolved "https://github.com/JamesLefrere/graph-cli.git#449c326f938a590a1685214c922fad70362f45a6"
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
     chalk "^3.0.0"
@@ -273,17 +272,6 @@ asn1@~0.2.3:
   integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   dependencies:
     safer-buffer "~2.1.0"
-
-"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
-  version "0.6.0"
-  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
-  dependencies:
-    "@protobufjs/utf8" "^1.1.0"
-    binaryen "77.0.0-nightly.20190407"
-    glob "^7.1.3"
-    long "^4.0.0"
-    opencollective-postinstall "^2.0.0"
-    source-map-support "^0.5.11"
 
 "assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"


### PR DESCRIPTION
Fixes the yarn resolution for the `graph-cli` fork; wasn't updated properly before.