### PR TITLE
Increment/decrement staking balances

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -6,8 +6,8 @@
   "startBlock_SavingsManager": 10000000,
   "address_BasketManager": "0x66126B4aA2a1C07536Ef8E5e8bD4EfDA1FdEA96D",
   "startBlock_BasketManager": 10000000,
-  "address_RewardsDistributor": "",
-  "startBlock_RewardsDistributor": 0,
-  "address_MTA": "",
-  "startBlock_MTA": 0
+  "address_RewardsDistributor": "0x04dfDfa471b79cc9E6E8C355e6C71F8eC4916C50",
+  "startBlock_RewardsDistributor": 10500000,
+  "address_MTA": "0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
+  "startBlock_MTA": 10000000
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -1,13 +1,13 @@
 {
   "network": "mainnet",
   "address_mUSD": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
-  "startBlock_mUSD": 10000000,
+  "startBlock_mUSD": 10585670,
   "address_SavingsManager": "0xcEfCBb45BE41331337d49a131faF424D1e50234f",
-  "startBlock_SavingsManager": 10000000,
+  "startBlock_SavingsManager": 10585670,
   "address_BasketManager": "0x66126B4aA2a1C07536Ef8E5e8bD4EfDA1FdEA96D",
-  "startBlock_BasketManager": 10000000,
-  "address_RewardsDistributor": "",
-  "startBlock_RewardsDistributor": 0,
-  "address_MTA": "",
-  "startBlock_MTA": 0
+  "startBlock_BasketManager": 10585670,
+  "address_RewardsDistributor": "0x04dfDfa471b79cc9E6E8C355e6C71F8eC4916C50",
+  "startBlock_RewardsDistributor": 10585670,
+  "address_MTA": "0xa3BeD4E1c75D00fa6f4E5E6922DB7261B5E9AcD2",
+  "startBlock_MTA": 10585670
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -423,7 +423,8 @@ type StakingRewardsContractTransaction implements Transaction @entity {
   stakingRewardsContract: StakingRewardsContract!
 }
 
-type StakingRewardsContractClaimRewardTransaction implements Transaction @entity {
+type StakingRewardsContractClaimRewardTransaction implements Transaction
+  @entity {
   id: ID!
 
   tx: Bytes!
@@ -482,7 +483,6 @@ type RewardsDistributor @entity {
   """
   fundManagers: [Bytes!]!
 }
-
 
 type StakingReward @entity {
   # contract + account
@@ -585,6 +585,24 @@ type StakingRewardsContract @entity {
   Accessor for staking rewards kept on this contract
   """
   stakingRewards: [StakingReward!]!
+    @derivedFrom(field: "stakingRewardsContract")
+
+  """
+  Accessor for claim reward transactions sent to this contract
+  """
+  claimRewardTransactions: [StakingRewardsContractClaimRewardTransaction!]!
+    @derivedFrom(field: "stakingRewardsContract")
+
+  """
+  Accessor for stake transactions sent to this contract
+  """
+  stakeTransactions: [StakingRewardsContractStakeTransaction!]!
+    @derivedFrom(field: "stakingRewardsContract")
+
+  """
+  Accessor for withdraw transactions sent to this contract
+  """
+  withdrawTransactions: [StakingRewardsContractWithdrawTransaction!]!
     @derivedFrom(field: "stakingRewardsContract")
 
   #######################################################

--- a/src/mappings/StakingRewards/StakingRewards.ts
+++ b/src/mappings/StakingRewards/StakingRewards.ts
@@ -25,28 +25,16 @@ export function handleRewardAdded(event: RewardAdded): void {
 }
 
 export function handleStaked(event: Staked): void {
-  handleStakedForType(
-    event.address,
-    StakingRewardsContractType.STAKING_REWARDS,
-    event.params.user,
-  )
+  handleStakedForType(event, StakingRewardsContractType.STAKING_REWARDS)
   getOrCreateStakingRewardsContractStakeTransaction(event)
 }
 
 export function handleWithdrawn(event: Withdrawn): void {
-  handleWithdrawnForType(
-    event.address,
-    StakingRewardsContractType.STAKING_REWARDS,
-    event.params.user,
-  )
+  handleWithdrawnForType(event, StakingRewardsContractType.STAKING_REWARDS)
   getOrCreateStakingRewardsContractWithdrawTransaction(event)
 }
 
 export function handleRewardPaid(event: RewardPaid): void {
-  handleRewardPaidForType(
-    event.address,
-    StakingRewardsContractType.STAKING_REWARDS,
-    event.params.user,
-  )
+  handleRewardPaidForType(event, StakingRewardsContractType.STAKING_REWARDS)
   getOrCreateStakingRewardsContractRewardPaidTransaction(event)
 }

--- a/src/mappings/StakingRewards/StakingRewardsWithPlatformToken.ts
+++ b/src/mappings/StakingRewards/StakingRewardsWithPlatformToken.ts
@@ -4,13 +4,23 @@ import {
   Staked,
   Withdrawn,
 } from '../../../generated/templates/StakingRewardsWithPlatformToken/StakingRewardsWithPlatformToken'
+import {
+  RewardPaid as RewardPaidBase,
+  Staked as StakedBase,
+  Withdrawn as WithdrawnBase,
+} from '../../../generated/templates/StakingRewards/StakingRewards'
 import { StakingRewardsContractType } from '../../enums'
 import {
   handleRewardAddedForType,
-  handleStakedForType,
   handleRewardPaidForType,
+  handleStakedForType,
   handleWithdrawnForType,
 } from './shared'
+import {
+  getOrCreateStakingRewardsContractRewardPaidTransaction,
+  getOrCreateStakingRewardsContractStakeTransaction,
+  getOrCreateStakingRewardsContractWithdrawTransaction,
+} from '../../models/Transaction'
 
 export function handleRewardAdded(event: RewardAdded): void {
   handleRewardAddedForType(
@@ -21,24 +31,26 @@ export function handleRewardAdded(event: RewardAdded): void {
 
 export function handleStaked(event: Staked): void {
   handleStakedForType(
-    event.address,
+    event as StakedBase,
     StakingRewardsContractType.STAKING_REWARDS_WITH_PLATFORM_TOKEN,
-    event.params.user,
   )
+  getOrCreateStakingRewardsContractStakeTransaction(event as StakedBase)
 }
 
 export function handleWithdrawn(event: Withdrawn): void {
   handleWithdrawnForType(
-    event.address,
+    event as WithdrawnBase,
     StakingRewardsContractType.STAKING_REWARDS_WITH_PLATFORM_TOKEN,
-    event.params.user,
   )
+  getOrCreateStakingRewardsContractWithdrawTransaction(event as WithdrawnBase)
 }
 
 export function handleRewardPaid(event: RewardPaid): void {
   handleRewardPaidForType(
-    event.address,
+    event as RewardPaidBase,
     StakingRewardsContractType.STAKING_REWARDS_WITH_PLATFORM_TOKEN,
-    event.params.user,
+  )
+  getOrCreateStakingRewardsContractRewardPaidTransaction(
+    event as RewardPaidBase,
   )
 }

--- a/src/models/StakingBalance.ts
+++ b/src/models/StakingBalance.ts
@@ -2,10 +2,10 @@ import { Address, BigInt } from '@graphprotocol/graph-ts'
 import { StakingBalance } from '../../generated/schema'
 
 export function getOrCreateStakingBalance(
-  account: Address,
   contractAddress: Address,
+  user: Address,
 ): StakingBalance {
-  let id = contractAddress.toHexString() + account.toHexString()
+  let id = contractAddress.toHexString() + user.toHexString()
 
   let stakingBalance = StakingBalance.load(id)
 
@@ -16,7 +16,7 @@ export function getOrCreateStakingBalance(
   {
     let stakingBalance = new StakingBalance(id)
 
-    stakingBalance.account = account
+    stakingBalance.account = user
     stakingBalance.amount = BigInt.fromI32(0)
     stakingBalance.stakingRewardsContract = contractAddress.toHexString()
 
@@ -24,4 +24,24 @@ export function getOrCreateStakingBalance(
 
     return stakingBalance as StakingBalance
   }
+}
+
+export function increaseStakingBalance(
+  contractAddress: Address,
+  user: Address,
+  amount: BigInt,
+): void {
+  let stakingBalance = getOrCreateStakingBalance(contractAddress, user)
+  stakingBalance.amount = stakingBalance.amount.plus(amount)
+  stakingBalance.save()
+}
+
+export function decreaseStakingBalance(
+  contractAddress: Address,
+  user: Address,
+  amount: BigInt,
+): void {
+  let stakingBalance = getOrCreateStakingBalance(contractAddress, user)
+  stakingBalance.amount = stakingBalance.amount.minus(amount)
+  stakingBalance.save()
 }

--- a/src/models/Transaction.ts
+++ b/src/models/Transaction.ts
@@ -97,7 +97,7 @@ export function getOrCreateStakingRewardsContractWithdrawTransaction(
   transaction.timestamp = event.block.timestamp.toI32()
   transaction.type = type
   transaction.amount = event.params.amount
-  transaction.stakingRewardsContract = event.transaction.to.toHexString()
+  transaction.stakingRewardsContract = event.address.toHexString()
   transaction.save()
 
   return transaction
@@ -126,7 +126,7 @@ export function getOrCreateStakingRewardsContractRewardPaidTransaction(
   transaction.timestamp = event.block.timestamp.toI32()
   transaction.type = type
   transaction.amount = event.params.reward
-  transaction.stakingRewardsContract = event.transaction.to.toHexString()
+  transaction.stakingRewardsContract = event.address.toHexString()
   transaction.save()
 
   return transaction
@@ -153,7 +153,7 @@ export function getOrCreateStakingRewardsContractStakeTransaction(
   transaction.timestamp = event.block.timestamp.toI32()
   transaction.type = type
   transaction.amount = event.params.amount
-  transaction.stakingRewardsContract = event.transaction.to.toHexString()
+  transaction.stakingRewardsContract = event.address.toHexString()
   transaction.save()
 
   return transaction

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,6 +123,18 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@typescript-eslint/eslint-plugin@^3.5.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.9.0.tgz#0fe529b33d63c9a94f7503ca2bb12c84b9477ff3"
+  integrity sha512-UD6b4p0/hSe1xdTvRCENSx7iQ+KR6ourlZFfYuPC7FlXEzdHuLPrEmuxZ23b2zW96KJX9Z3w05GE/wNOiEzrVg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "3.9.0"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/experimental-utils@3.5.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.5.0.tgz#d09f9ffb890d1b15a7ffa9975fae92eee05597c4"
@@ -131,6 +143,17 @@
     "@types/json-schema" "^7.0.3"
     "@typescript-eslint/types" "3.5.0"
     "@typescript-eslint/typescript-estree" "3.5.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/experimental-utils@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.0.tgz#3171d8ddba0bf02a8c2034188593630914fcf5ee"
+  integrity sha512-/vSHUDYizSOhrOJdjYxPNGfb4a3ibO8zd4nUKo/QBFOmxosT3cVUV7KIg8Dwi6TXlr667G7YPqFK9+VSZOorNA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/types" "3.9.0"
+    "@typescript-eslint/typescript-estree" "3.9.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -150,6 +173,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.5.0.tgz#4e3d2a2272268d8ec3e3e4a37152a64956682639"
   integrity sha512-Dreqb5idi66VVs1QkbAwVeDmdJG+sDtofJtKwKCZXIaBsINuCN7Jv5eDIHrS0hFMMiOvPH9UuOs4splW0iZe4Q==
 
+"@typescript-eslint/types@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.9.0.tgz#be9d0aa451e1bf3ce99f2e6920659e5b2e6bfe18"
+  integrity sha512-rb6LDr+dk9RVVXO/NJE8dT1pGlso3voNdEIN8ugm4CWM5w5GimbThCMiMl4da1t5u3YwPWEwOnKAULCZgBtBHg==
+
 "@typescript-eslint/typescript-estree@3.5.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.5.0.tgz#dfc895db21a381b84f24c2a719f5bf9c600dcfdc"
@@ -164,10 +192,31 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.0.tgz#c6abbb50fa0d715cab46fef67ca6378bf2eaca13"
+  integrity sha512-N+158NKgN4rOmWVfvKOMoMFV5n8XxAliaKkArm/sOypzQ0bUL8MSnOEBW3VFIeffb/K5ce/cAV0yYhR7U4ALAA==
+  dependencies:
+    "@typescript-eslint/types" "3.9.0"
+    "@typescript-eslint/visitor-keys" "3.9.0"
+    debug "^4.1.1"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/visitor-keys@3.5.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.5.0.tgz#73c1ea2582f814735e4afdc1cf6f5e3af78db60a"
   integrity sha512-7cTp9rcX2sz9Z+zua9MCOX4cqp5rYyFD5o8LlbSpXrMTXoRdngTtotRZEkm8+FNMHPWYFhitFK+qt/brK8BVJQ==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/visitor-keys@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.0.tgz#44de8e1b1df67adaf3b94d6b60b80f8faebc8dd3"
+  integrity sha512-O1qeoGqDbu0EZUC/MZ6F1WHTIzcBVhGqDj3LhTnj65WUA548RXVxUHbYhAW9bZWfb2rnX9QsbbP5nmeJ5Z4+ng==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
@@ -3021,7 +3070,7 @@ regenerator-runtime@^0.13.2:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==


### PR DESCRIPTION
In some cases, staking balances were not being updated properly. This PR fixes that by not relying on `balanceOf` calls, and rather using the event parameters:

- Increment and decrement staking balances on `Stake`/`Withdrawn` events
- Ensure staking transaction entities are created and have the correct ID

Tested locally with mainnet staging on a partial deploy (i.e. just EARN). Final steps are to wait for the full mainnet staging deploy, test locally or on staging, and then deploy to mainnet. 